### PR TITLE
Downgrade to Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.10.0</version>
 				<configuration>
-					<release>17</release>
+					<source>1.8</source>
+					<target>1.8</target>
 					<annotationProcessorPaths>
 						<path>
 							<groupId>org.openjdk.jmh</groupId>
@@ -31,8 +32,8 @@
 				<artifactId>jmh-maven-plugin</artifactId>
 				<version>0.2.2</version>
 				<configuration>
-					<source>17</source>
-					<target>17</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<warmupIterations>0</warmupIterations>
 					<warmupForks>0</warmupForks>
 					<fork>1</fork>

--- a/src/main/java/clipper2/Clipper.java
+++ b/src/main/java/clipper2/Clipper.java
@@ -21,6 +21,7 @@ import clipper2.engine.Clipper64;
 import clipper2.engine.ClipperD;
 import clipper2.engine.PointInPolygonResult;
 import clipper2.engine.PolyPath64;
+import clipper2.engine.PolyPathBase;
 import clipper2.engine.PolyPathD;
 import clipper2.engine.PolyTree64;
 import clipper2.engine.PolyTreeD;
@@ -668,7 +669,7 @@ public final class Clipper {
 
 	public static PathsD PolyTreeToPathsD(PolyTreeD polyTree) {
 		PathsD result = new PathsD();
-		for (var polyPathBase : polyTree) {
+		for (PolyPathBase polyPathBase : polyTree) {
 			PolyPathD p = (PolyPathD) polyPathBase;
 			AddPolyNodeToPathsD(p, result);
 		}

--- a/src/main/java/clipper2/core/Point64.java
+++ b/src/main/java/clipper2/core/Point64.java
@@ -80,7 +80,8 @@ public final class Point64 {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof Point64 p) {
+		if (obj instanceof Point64) {
+			Point64 p = (Point64) obj;
 			return opEquals(this, p);
 		}
 		return false;

--- a/src/main/java/clipper2/core/PointD.java
+++ b/src/main/java/clipper2/core/PointD.java
@@ -62,7 +62,8 @@ public final class PointD {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof PointD p) {
+		if (obj instanceof PointD) {
+			PointD p = (PointD) obj;
 			return opEquals(this, p);
 		}
 		return false;

--- a/src/main/java/clipper2/engine/ClipperBase.java
+++ b/src/main/java/clipper2/engine/ClipperBase.java
@@ -768,24 +768,37 @@ abstract class ClipperBase {
 
 		switch (cliptype) {
 			case Intersection :
-				return switch (fillrule) {
-					case Positive -> ae.windCount2 > 0;
-					case Negative -> ae.windCount2 < 0;
-					default -> ae.windCount2 != 0;
-				};
+				switch (fillrule) {
+					case Positive:
+						return ae.windCount2 > 0;
+					case Negative:
+						return ae.windCount2 < 0;
+					default:
+						return ae.windCount2 != 0;
+				}
 			case Union :
-				return switch (fillrule) {
-					case Positive -> ae.windCount2 <= 0;
-					case Negative -> ae.windCount2 >= 0;
-					default -> ae.windCount2 == 0;
-				};
+				switch (fillrule) {
+					case Positive:
+						return ae.windCount2 <= 0;
+					case Negative:
+						return ae.windCount2 >= 0;
+					default:
+						return ae.windCount2 == 0;
+				}
 
 			case Difference :
-				boolean result = switch (fillrule) {
-					case Positive -> ae.windCount2 <= 0;
-					case Negative -> ae.windCount2 >= 0;
-					default -> ae.windCount2 == 0;
-				};
+				boolean result;
+				switch (fillrule) {
+					case Positive:
+						result = ae.windCount2 <= 0;
+						break;
+					case Negative:
+						result = ae.windCount2 >= 0;
+						break;
+					default:
+						result = ae.windCount2 == 0;
+						break;
+				}
 				return (GetPolyType(ae) == PathType.Subject) ? result : !result;
 			case Xor :
 				return true; // XOr is always contributing unless open
@@ -811,11 +824,14 @@ abstract class ClipperBase {
 				break;
 		}
 
-		return switch (cliptype) {
-			case Intersection -> isInClip;
-			case Union -> !isInSubj && !isInClip;
-			default -> !isInClip;
-		};
+		switch (cliptype) {
+			case Intersection:
+				return isInClip;
+			case Union:
+				return !isInSubj && !isInClip;
+			default:
+				return !isInClip;
+		}
 	}
 
 	private void SetWindCountForClosedPathEdge(Active ae) {

--- a/src/main/java/clipper2/engine/LocalMinima.java
+++ b/src/main/java/clipper2/engine/LocalMinima.java
@@ -33,7 +33,8 @@ final class LocalMinima {
 	@Override
 	public
 	boolean equals(Object obj) {
-		if (obj instanceof LocalMinima minima) {
+		if (obj instanceof LocalMinima) {
+			LocalMinima minima = (LocalMinima) obj;
 			return this == minima;
 		}
 		return false;

--- a/src/main/java/clipper2/engine/PolyPath64.java
+++ b/src/main/java/clipper2/engine/PolyPath64.java
@@ -38,7 +38,7 @@ public class PolyPath64 extends PolyPathBase {
 
 	public final double Area() {
 		double result = getPolygon() == null ? 0 : Clipper.Area(getPolygon());
-		for (var polyPathBase : children) {
+		for (PolyPathBase polyPathBase : children) {
 			PolyPath64 child = (PolyPath64) polyPathBase;
 			result += child.Area();
 		}

--- a/src/main/java/clipper2/engine/PolyPathD.java
+++ b/src/main/java/clipper2/engine/PolyPathD.java
@@ -36,7 +36,7 @@ public class PolyPathD extends PolyPathBase {
 
 	public final double Area() {
 		double result = getPolygon() == null ? 0 : Clipper.Area(getPolygon());
-		for (var polyPathBase : children) {
+		for (PolyPathBase polyPathBase : children) {
 			PolyPathD child = (PolyPathD) polyPathBase;
 			result += child.Area();
 		}

--- a/src/test/java/clipper2/BenchmarkClipper1.java
+++ b/src/test/java/clipper2/BenchmarkClipper1.java
@@ -67,8 +67,8 @@ public class BenchmarkClipper1 {
 	}
 
 	private static LongPoint MakeRandomPt(int maxWidth, int maxHeight, Random rand) {
-		long x = rand.nextLong(maxWidth);
-		long y = rand.nextLong(maxHeight);
+		long x = rand.nextInt(maxWidth);
+		long y = rand.nextInt(maxHeight);
 		return new LongPoint(x, y);
 	}
 

--- a/src/test/java/clipper2/BenchmarkClipper2.java
+++ b/src/test/java/clipper2/BenchmarkClipper2.java
@@ -66,8 +66,8 @@ public class BenchmarkClipper2 {
 	}
 
 	private static Point64 MakeRandomPt(int maxWidth, int maxHeight, Random rand) {
-		long x = rand.nextLong(maxWidth);
-		long y = rand.nextLong(maxHeight);
+		long x = rand.nextInt(maxWidth);
+		long y = rand.nextInt(maxHeight);
 		return new Point64(x, y);
 	}
 

--- a/src/test/java/clipper2/ClipperFileIO.java
+++ b/src/test/java/clipper2/ClipperFileIO.java
@@ -14,12 +14,75 @@ import clipper2.core.Point64;
 
 class ClipperFileIO {
 
-	record TestCase(String caption, ClipType clipType, FillRule fillRule, long area, int count, int GetIdx, Paths64 subj, Paths64 subj_open,
-			Paths64 clip, int testNum) {
+	static class TestCase{
+		private final String caption;
+		private final ClipType clipType;
+		private final FillRule fillRule;
+		private final long area;
+		private final int count;
+		private final int GetIdx;
+		private final Paths64 subj;
+		private final Paths64 subj_open;
+		private final Paths64 clip;
+		private final int testNum;
+
+		TestCase(
+	String caption, ClipType clipType, FillRule fillRule, long area, int count, int GetIdx, Paths64 subj, Paths64 subj_open, Paths64 clip, int testNum) {
+			this.caption = caption;
+			this.clipType = clipType;
+			this.fillRule = fillRule;
+			this.area = area;
+			this.count = count;
+			this.GetIdx = GetIdx;
+			this.subj = subj;
+			this.subj_open = subj_open;
+			this.clip = clip;
+			this.testNum = testNum;
+		}
+
+		public String caption() {
+			return caption;
+		}
+
+		public ClipType clipType() {
+			return clipType;
+		}
+
+		public FillRule fillRule() {
+			return fillRule;
+		}
+
+		public long area() {
+			return area;
+		}
+
+		public int count() {
+			return count;
+		}
+
+		public int GetIdx() {
+			return GetIdx;
+		}
+
+		public Paths64 subj() {
+			return subj;
+		}
+
+		public Paths64 subj_open() {
+			return subj_open;
+		}
+
+		public Paths64 clip() {
+			return clip;
+		}
+
+		public int testNum() {
+			return testNum;
+		}
 	}
 
 	static List<TestCase> loadTestCases(String testFileName) throws IOException {
-		List<String> lines = Files.readAllLines(Paths.get("src/test/resources/%s".formatted(testFileName)));
+		List<String> lines = Files.readAllLines(Paths.get(String.format("src/test/resources/%s", testFileName)));
 
 		String caption = "";
 		ClipType ct = ClipType.None;
@@ -27,14 +90,14 @@ class ClipperFileIO {
 		long area = 0;
 		int count = 0;
 		int GetIdx = 0;
-		var subj = new Paths64();
-		var subj_open = new Paths64();
-		var clip = new Paths64();
+		Paths64 subj = new Paths64();
+		Paths64 subj_open = new Paths64();
+		Paths64 clip = new Paths64();
 
 		List<TestCase> cases = new ArrayList<>();
 
 		for (String s : lines) {
-			if (s.isBlank() || s.length() == 0) {
+			if (s.matches("\\s*") || s.length() == 0) {
 				cases.add(new TestCase(caption, ct, fillRule, area, count, GetIdx, new Paths64(subj), new Paths64(subj_open),
 						new Paths64(clip), cases.size()+1));
 				subj.clear();
@@ -136,8 +199,8 @@ class ClipperFileIO {
 		Path64 p = new Path64();
 		Paths64 pp = new Paths64();
 
-		for (var pair : s.split(" ")) {
-			var xy = pair.split(",");
+		for (String pair : s.split(" ")) {
+			String[] xy = pair.split(",");
 			long x = Long.parseLong(xy[0]);
 			long y = Long.parseLong(xy[1]);
 			p.add(new Point64(x, y));

--- a/src/test/java/clipper2/TestLines.java
+++ b/src/test/java/clipper2/TestLines.java
@@ -24,8 +24,8 @@ class TestLines {
 	@ParameterizedTest(name = "{0} {2} {3}")
 	final void RunLinesTestCase(TestCase test, String caption, Object o, Object o1) {
 		Clipper64 c64 = new Clipper64();
-		var solution = new Paths64();
-		var solution_open = new Paths64();
+		Paths64 solution = new Paths64();
+		Paths64 solution_open = new Paths64();
 
 		c64.AddSubject(test.subj());
 		c64.AddOpenSubject(test.subj_open());

--- a/src/test/java/clipper2/TestPolygons.java
+++ b/src/test/java/clipper2/TestPolygons.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Arrays;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.params.ParameterizedTest;
@@ -25,8 +25,8 @@ class TestPolygons {
 	@ParameterizedTest(name = "{1}: {2} {3}")
 	final void RunPolygonsTestCase(TestCase test, int testNum, Object o, Object o1) {
 		Clipper64 c64 = new Clipper64();
-		var solution = new Paths64();
-		var solution_open = new Paths64();
+		Paths64 solution = new Paths64();
+		Paths64 solution_open = new Paths64();
 
 		c64.AddSubject(test.subj());
 		c64.AddOpenSubject(test.subj_open());
@@ -42,7 +42,7 @@ class TestPolygons {
 			assertTrue(countDiff <= 4);
 		} else if (test.testNum() == 27) {
 			assertTrue(countDiff <= 2);
-		} else if (List.of(18, 32, 42, 43, 45, 87, 102, 103, 111, 118, 183).contains(test.testNum())) {
+		} else if (Arrays.asList(18, 32, 42, 43, 45, 87, 102, 103, 111, 118, 183).contains(test.testNum())) {
 			assertTrue(countDiff <= 1);
 		} else if (test.testNum() >= 120) {
 			if (test.count() > 0) {
@@ -53,7 +53,7 @@ class TestPolygons {
 			assertEquals(0, countDiff, String.format("Vertex count incorrect. Expected=%s; actual=%s", test.count(), measuredCount));
 		}
 
-		if (List.of(22, 23, 24).contains(test.testNum())) {
+		if (Arrays.asList(22, 23, 24).contains(test.testNum())) {
 			assertTrue(areaDiff <= 8);
 		} else if (test.area() > 0 && areaDiff > 100) {
 			assertTrue(areaDiff / test.area() <= 0.02);

--- a/src/test/java/clipper2/TestPolytree.java
+++ b/src/test/java/clipper2/TestPolytree.java
@@ -3,9 +3,12 @@ package clipper2;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
+import clipper2.core.Path64;
+import clipper2.engine.PolyPathBase;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -33,26 +36,26 @@ class TestPolytree {
 		Paths64 solution_open = new Paths64();
 		Clipper64 clipper = new Clipper64();
 
-		var subject = test.subj();
-		var subjectOpen = test.subj_open();
-		var clip = test.clip();
+		Paths64 subject = test.subj();
+		Paths64 subjectOpen = test.subj_open();
+		Paths64 clip = test.clip();
 
-		var pointsOfInterestOutside = List.of(new Point64(21887, 10420), new Point64(21726, 10825), new Point64(21662, 10845),
+		List<Point64> pointsOfInterestOutside = Arrays.asList(new Point64(21887, 10420), new Point64(21726, 10825), new Point64(21662, 10845),
 				new Point64(21617, 10890));
 
 		for (Point64 pt : pointsOfInterestOutside) {
-			for (var path : subject) {
+			for (Path64 path : subject) {
 				assertEquals(PointInPolygonResult.IsOutside, Clipper.PointInPolygon(pt, path),
 						"outside point of interest found inside subject");
 			}
 		}
 
-		var pointsOfInterestInside = List.of(new Point64(21887, 10430), new Point64(21843, 10520), new Point64(21810, 10686),
+		List<Point64> pointsOfInterestInside = Arrays.asList(new Point64(21887, 10430), new Point64(21843, 10520), new Point64(21810, 10686),
 				new Point64(21900, 10461));
 
 		for (Point64 pt : pointsOfInterestInside) {
 			int poi_inside_counter = 0;
-			for (var path : subject) {
+			for (Path64 path : subject) {
 				if (Clipper.PointInPolygon(pt, path) == PointInPolygonResult.IsInside) {
 					poi_inside_counter++;
 				}
@@ -65,7 +68,7 @@ class TestPolytree {
 		clipper.AddClip(clip);
 		clipper.Execute(test.clipType(), test.fillRule(), solutionTree, solution_open);
 
-		var solutionPaths = Clipper.PolyTreeToPaths64(solutionTree);
+		Paths64 solutionPaths = Clipper.PolyTreeToPaths64(solutionTree);
 		double a1 = Clipper.Area(solutionPaths), a2 = solutionTree.Area();
 
 		assertTrue(a1 > 330000, String.format("solution has wrong area - value expected: 331,052; value returned; %1$s ", a1));
@@ -86,7 +89,7 @@ class TestPolytree {
 	}
 
 	private static boolean CheckPolytreeFullyContainsChildren(PolyTree64 polytree) {
-		for (var p : polytree) {
+		for (PolyPathBase p : polytree) {
 			PolyPath64 child = (PolyPath64) p;
 			if (child.getCount() > 0 && !PolyPathFullyContainsChildren(child)) {
 				return false;
@@ -96,8 +99,8 @@ class TestPolytree {
 	}
 
 	private static boolean PolyPathFullyContainsChildren(PolyPath64 pp) {
-		for (var c : pp) {
-			var child = (PolyPath64) c;
+		for (PolyPathBase c : pp) {
+			PolyPath64 child = (PolyPath64) c;
 			for (Point64 pt : child.getPolygon()) {
 				if (Clipper.PointInPolygon(pt, pp.getPolygon()) == PointInPolygonResult.IsOutside) {
 					return false;


### PR DESCRIPTION
Maybe it's a good idea to downgrade this library to Java 8 which makes usable in more projects.
It seems to me that Java 8 is the default for libraries.
(We are planning to use this Clipper2 library in our project which is limited to Java 8 for some reasons.)

From a technical perspective, this downgrade requires only a few code changes (less syntactic sugar; record class rewritten).

I was not able to check that JMH works. My Maven did not produce benchmarks.jar.