### PR TITLE
Add module-info.java as multi release jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>micycle</groupId>
 	<artifactId>clipper2</artifactId>
@@ -27,6 +27,34 @@
 						</path>
 					</annotationProcessorPaths>
 				</configuration>
+				<executions>
+					<execution>
+						<id>compile-java-9</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+						<configuration>
+							<release>9</release>
+							<compileSourceRoots>
+								<compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
+							</compileSourceRoots>
+							<multiReleaseOutput>true</multiReleaseOutput>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.3.0</version>
+				<configuration>
+					<archive>
+						<manifestEntries>
+							<Multi-Release>true</Multi-Release>
+						</manifestEntries>
+					</archive>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>pw.krejci</groupId>
@@ -46,7 +74,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.2</version>
+				<version>3.1.2</version>
 				<configuration>
 					<forkCount>4</forkCount>
 					<reuseForks>false</reuseForks>
@@ -55,7 +83,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>3.2.1</version>
+				<version>3.3.0</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>
@@ -68,10 +96,11 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.5.0</version>
+				<version>3.6.0</version>
 				<configuration>
 					<failOnError>false</failOnError>
 					<doclint>all</doclint>
+					<source>8</source>
 				</configuration>
 				<executions>
 					<execution>

--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -1,0 +1,9 @@
+module clipper2 {
+    exports clipper2;
+    exports clipper2.core;
+    exports clipper2.engine;
+    exports clipper2.offset;
+    exports clipper2.rectclip;
+
+    exports tangible;
+}


### PR DESCRIPTION
Hi and thanks for your porting effort.

This pull request adds a `module-info.java` file which
allows an user to use the library as java module named `clipper2` with jigsaw. It uses the multi release feature, hence should still be valid for an java 8 environment.

An alternative to this pull request could be an `Automatic-Module-Name` manifest entry.
I think this pull request is non disruptive and the better way, but the manifest solution would be simpler and in the end there would be little difference from the library user point of view.

Have a nice day

-ClaasJG

