### PR TITLE
Change scope for jmh dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,11 +130,13 @@
 			<groupId>org.openjdk.jmh</groupId>
 			<artifactId>jmh-core</artifactId>
 			<version>${jmh.version}</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.openjdk.jmh</groupId>
 			<artifactId>jmh-generator-annprocess</artifactId>
 			<version>${jmh.version}</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>pw.krejci</groupId>


### PR DESCRIPTION
Hi,

currently, `clipper2-java` leaks `jmh-core` and `jmh-generator-annprocess` when consuming it via [jitpack.io](https://jitpack.io/).
Both dependencies are only required for the JMH benchmarks. Based on the [readme ](https://github.com/metlos/jmh-maven-plugin#notes) of the used jmh plugin 

> This plugin does not generate the uber-jar as is usual with the default JMH approach. It instead just invokes the benchmark with the test classpath.

which means, that those dependencies can use the `test `scope.

Thanks for the port and have a nice day

-ClaasJG