### PR TITLE
Fix mutation of global state 'InvalidRect64'/'InvalidRectD' by 'GetBounds' variants.

### DIFF
--- a/src/main/java/clipper2/Clipper.java
+++ b/src/main/java/clipper2/Clipper.java
@@ -677,7 +677,7 @@ public final class Clipper {
 	}
 
 	public static Rect64 GetBounds(Path64 path) {
-		Rect64 result = InvalidRect64;
+		Rect64 result = InvalidRect64.clone();
 		for (Point64 pt : path) {
 			if (pt.x < result.left) {
 				result.left = pt.x;
@@ -696,7 +696,7 @@ public final class Clipper {
 	}
 
 	public static Rect64 GetBounds(Paths64 paths) {
-		Rect64 result = InvalidRect64;
+		Rect64 result = InvalidRect64.clone();
 		for (Path64 path : paths) {
 			for (Point64 pt : path) {
 				if (pt.x < result.left) {
@@ -717,7 +717,7 @@ public final class Clipper {
 	}
 
 	public static RectD GetBounds(PathD path) {
-		RectD result = InvalidRectD;
+		RectD result = InvalidRectD.clone();
 		for (PointD pt : path) {
 			if (pt.x < result.left) {
 				result.left = pt.x;
@@ -736,7 +736,7 @@ public final class Clipper {
 	}
 
 	public static RectD GetBounds(PathsD paths) {
-		RectD result = InvalidRectD;
+		RectD result = InvalidRectD.clone();
 		for (PathD path : paths) {
 			for (PointD pt : path) {
 				if (pt.x < result.left) {

--- a/src/main/java/clipper2/engine/ClipperBase.java
+++ b/src/main/java/clipper2/engine/ClipperBase.java
@@ -2778,7 +2778,7 @@ abstract class ClipperBase {
 		if (path.isEmpty()) {
 			return new Rect64();
 		}
-		Rect64 result = Clipper.InvalidRect64;
+		Rect64 result = Clipper.InvalidRect64.clone();
 		for (Point64 pt : path) {
 			if (pt.x < result.left) {
 				result.left = pt.x;
@@ -2893,7 +2893,7 @@ abstract class ClipperBase {
 	}
 
 	public final Rect64 GetBounds() {
-		Rect64 bounds = Clipper.InvalidRect64;
+		Rect64 bounds = Clipper.InvalidRect64.clone();
 		for (Vertex t : vertexList) {
 			Vertex v = t;
 			do {


### PR DESCRIPTION
Hi,

`Clipper.GetBounds`  changes the state of `InvalidRect64` and `InvalidRectD`.
Therefor `GetBounds` accumulates the biggest bounds over the lifetime of the program and does not compute the requested bounds for the requested path.

While this can be worked around by the user (because those fields are mutable and public)
it makes the static utility functions dependent on global state and therefor prohibits the usage in a multi threaded context.

~I think the same bug (or at least absolutely annoying and unexpected behaviour) can be found in the original C# implementation.~ (EDIT: The original implementation implements `Rect64` and `RectD` as struct and therefor as `ValueType`. Which means this port differs currently in behaviour. )

Have a nice day

-ClaasJG